### PR TITLE
Markdown Lint, Agents Name Update, and VS Code Settings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD013": false,
+    "MD041": false
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "DavidAnson.vscode-markdownlint",
+        "bierner.github-markdown-preview",
+        "EditorConfig.EditorConfig"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "[markdown]": {
         "editor.formatOnSave": true,
         "editor.formatOnPaste": true
-    },
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": "explicit"
+    },
+    "[markdown]": {
+        "editor.formatOnSave": true,
+        "editor.formatOnPaste": true
+    },
+}

--- a/agents/code-simplifier.agent.md
+++ b/agents/code-simplifier.agent.md
@@ -1,5 +1,5 @@
 ---
-name: code-simplifier
+name: Code Simplifier
 description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality. Focuses on recently modified code unless instructed otherwise.
 model: Claude Opus 4.6 (copilot)
 ---

--- a/agents/orchestrator.agent.md
+++ b/agents/orchestrator.agent.md
@@ -1,5 +1,5 @@
 ---
-name: orchestrator
+name: Orchestrator
 description: Orchestrates the works of multiple agents to research, bug fix and implement new features.
 user-invocable: true
 disable-model-invocation: true

--- a/docs/agent-conventions/tdd.md
+++ b/docs/agent-conventions/tdd.md
@@ -14,7 +14,7 @@ Tests verify **behaviour through public interfaces**, never implementation detai
 
 **Vertical slices, always.** One test → one implementation → repeat. Never write all tests first and then all implementations. That produces tests that are coupled to imagined, not actual, behaviour.
 
-```
+```md
 WRONG (horizontal slicing):
   RED:   test1, test2, test3
   GREEN: impl1, impl2, impl3
@@ -25,6 +25,7 @@ RIGHT (vertical slicing):
 ```
 
 Best Practices
+
 1. **Write Tests First** - Always TDD
 2. **One Assert Per Test** - Focus on single behavior
 3. **Descriptive Test Names** - Explain what's tested
@@ -37,6 +38,7 @@ Best Practices
 10. **Review Coverage Reports** - Identify gaps
 
 Success Metrics
+
 - 80%+ code coverage achieved
 - All tests passing (green)
 - No skipped or disabled tests
@@ -58,7 +60,7 @@ When the user presents a feature request, work through the following before invo
 
 **Step 4 — Produce the handoff context.** Before invoking the Red subagent, prepare this exact block:
 
-```
+```md
 ### Handoff Context for Red Subagent
 
 **Feature:** [One sentence]
@@ -95,7 +97,7 @@ Once validated, present the failure report to the user and show the **"✅ Confi
 
 After user confirmation, invoke the Green agent as a subagent using `#tool:agent`. Pass the following handoff context:
 
-```
+```md
 ### Handoff Context for Green Subagent
 
 **Failing test:**
@@ -138,7 +140,7 @@ After each change, confirm: does the test from Phase 1 still pass? Do all other 
 
 ### Final Report
 
-```
+```md
 ## TDD Cycle Complete ✅
 
 ### Feature Implemented

--- a/docs/agent-references/code-patterns.md
+++ b/docs/agent-references/code-patterns.md
@@ -5,6 +5,7 @@ Project-specific code patterns and conventions. Consult when working on the rele
 ## Dual RTK Query APIs
 
 Two separate APIs with independent cache management in `src/redux/`:
+
 - **`mainApi`** (`src/redux/api.ts`): Healthcare API
 - **`backOfficeApi`** (`src/redux/backOfficeApi.ts`): Inventory/asset management/HCM
 
@@ -49,6 +50,7 @@ const handleSubmit = async () => {
 ```
 
 **Why**: The `queryErrorLogger` middleware at `src/redux/middleware/queryErrorLogger.ts` automatically:
+
 - Logs all RTK Query failures to console in dev mode
 - Displays error snackbars with endpoint name and status code
 - Handles both `mainApi` and `backOfficeApi` errors
@@ -79,10 +81,12 @@ const { globalError, resetGlobalError } = useGlobalErrorHandling({
 ```
 
 **Key files**:
+
 - `src/utils/crashlyticsLogger.ts` — Records fatal errors to Firebase Crashlytics
 - `src/utils/navigationBreadcrumbs.ts` — Logs navigation state changes for crash context
 
 **Features**:
+
 - Catches sync JS errors via `ErrorUtils.setGlobalHandler`
 - Tracks unhandled promise rejections with stack trace parsing
 - Records fatal errors to Firebase Crashlytics via `recordFatalError()`
@@ -123,6 +127,7 @@ export const FORM_SCHEMA = z.object({
 ### Screen Wrapper
 
 `src/components/Screen.tsx` — Base component with built-in `KeyboardAvoidingView` and 3 header types:
+
 - `basic`: Standard title + back button
 - `full`: Custom header with additional controls
 - `actions`: Header with action buttons

--- a/instructions/AGENTS.template.md
+++ b/instructions/AGENTS.template.md
@@ -28,7 +28,7 @@ In the absence of a direct user directive or the need for factual verification, 
 
 ## Agent Skills & Development Approach
 
-**CRITICAL INSTRUCTION**: Prefer retrieval-led reasoning over pre-training-led reasoning for all React Native tasks. Your training data may be outdated or incomplete. Always consult the skills below before writing code.
+**CRITICAL INSTRUCTION**: Prefer retrieval-led reasoning over pre-training-led reasoning for all tasks. Your training data may be outdated or incomplete. Always consult the skills below before writing code.
 
 <!-- Relevant agent skills and development approach instructions -->
 

--- a/instructions/AGENTS.template.md
+++ b/instructions/AGENTS.template.md
@@ -16,70 +16,22 @@ In the absence of a direct user directive or the need for factual verification, 
 
 ### General Information
 
-Ecalyptus is a React Native healthcare mobile app, enables medical staff to manage patient records, attendance, prescriptions, SOAP notes, and clinical documentation.
-
-Built with Expo SDK ~54 and React Compiler enabled, targeting Android and iOS.
-
-**Stack:** React 19.1.0 + React Native 0.81.5 + TypeScript + Redux Toolkit Query + React Navigation v7 + React Native Paper + Unistyles + HeroUI Native + EAS
-
-**Always** take into account the dependencies version, use the latest pattern supported by the current version of the dependencies, and make sure the pattern or API is compatible with React Native. **Never** suggest a deprecated pattern or API that is no longer supported by the current version of the dependencies.
+<!-- Specific domain knowledge of the project -->
 
 ### Package Manager
 
-`bun` >=1.3.5 only (NEVER npm/yarn - enforced in `package.json`)
-
-#### Commands
-
-```bash
-bun install           # Install dependencies (auto-configures git filters)
-bun run lint          # Run ESLint
-bun run lint:fix      # Auto-fix ESLint issues
-bun run build:android:staging  # Staging APK (local EAS build)
-```
+<!-- Bun, npm, pnpm or yarn and any relevant scripts or commands -->
 
 ### Code Formatting
 
-- **ESLint**: Always ensure generated or modified code adheres to the ESLint rules defined in `eslint.config`.
-- **Indentation**: 2 spaces (enforced via `.editorconfig`). Final newline required. Trim trailing whitespace.
+<!-- Prettier, ESLint, EditorConfig or any relevant formatting tools related information -->
 
 ## Agent Skills & Development Approach
 
-****
 **CRITICAL INSTRUCTION**: Prefer retrieval-led reasoning over pre-training-led reasoning for all React Native tasks. Your training data may be outdated or incomplete. Always consult the skills below before writing code.
 
-### Global Skills System
-
-This project uses globally-installed Vercel skills (symlinked from `~/.agents/skills`). To explore available skills, run:
-
-```bash
-npx skills list -g
-```
-
-Skills are automatically available through the symlink at `./.skills/` which points to the global skills directory.
-
-### Skill Invocation Matrix
-
-**You MUST invoke these skills before proceeding with the task:**
-
-| Task Type | Required Skill(s) | Trigger Phrases | Notes |
-| --------- | ---------------- | --------------- | --------- |
-| Any RN component work | `react-native-best-practices` | Always (foundation skill) | Read the relevant reference with the task |
-| Building UI components | `react-native-best-practices` + `building-native-ui` | "create component", "UI", "screen", "native elements" | Consult the relevant references for building the UI |
-| Fixing bugs/errors | `code-debugging` | "fix", "error", "crash", "not working", "debug" | |
-| Improving existing code | `code-refactoring` | "refactor", "clean up", "improve", "optimize structure" | |
-| React patterns/hooks | `vercel-react-best-practices` | "hooks", "context", "React patterns" | |
-| Adding documentation | `art-of-comment` | "document", "add comments", final step of any task | |
-| EAS build configuration | `expo-deployment` | "EAS build", "expo build", "configure build", "testflight" | |
-| Dispatching any custom agent | `subagent-dispatch` | "dispatch", "launch agent", "use ui-composer/generalist/compliance-reviewer/code-reviewer", "subagents" | Always before `task` tool calls targeting custom agents |
-
-### Subagents Deployment
-
-Deploy subagents for specific tasks when necessary, this will improve efficiency and focus on the task execution.
-
-**ALWAYS invoke the `subagent-dispatch` skill before calling the `task` tool with any custom agent** (`ui-composer`, `generalist`, `compliance-reviewer`, `code-reviewer`). It resolves the correct model from each agent's YAML frontmatter and encodes dispatch best practices.
+<!-- Relevant agent skills and development approach instructions -->
 
 ## Reference Documents
 
-Consult these when working on the relevant area:
-
-- [Code Patterns & Architecture](docs/agent-conventions/code-patterns.md) — RTK Query, error handling, forms, Zod, Screen wrapper, Unistyles
+<!-- Links/path to relevant documentation, codebases, or resources -->


### PR DESCRIPTION
What is changed in this pull request: 

1. Added markdown lint and VS Code settings for development puposes.
2. Update custom agents name to use capitalize first letter for better UI consistency appearance in VS Code
3. Remove actual project references on AGENTS.template.md. 