### PR TITLE
Automate plugin version synchronization and pre-commit validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ staged="$(git diff --cached --name-only)"
 any_staged=false
 
 for f in "${WATCHED_FILES[@]}"; do
-  if echo "$staged" | grep -qF "$f"; then
+  if echo "$staged" | grep -qxF "$f"; then
     any_staged=true
     break
   fi
@@ -32,7 +32,7 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
-plugin_version="$(jq -r '.version' plugin.json)"
+plugin_version="$(git show :plugin.json | jq -r '.version')"
 mismatch=false
 
 check() {
@@ -44,11 +44,11 @@ check() {
   fi
 }
 
-check ".claude-plugin/plugin.json (.version)"                  "$(jq -r '.version'            .claude-plugin/plugin.json)"
-check ".github/plugin/marketplace.json (.metadata.version)"    "$(jq -r '.metadata.version'   .github/plugin/marketplace.json)"
-check ".github/plugin/marketplace.json (.plugins[0].version)"  "$(jq -r '.plugins[0].version' .github/plugin/marketplace.json)"
-check ".claude-plugin/marketplace.json (.metadata.version)"    "$(jq -r '.metadata.version'   .claude-plugin/marketplace.json)"
-check ".claude-plugin/marketplace.json (.plugins[0].version)"  "$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
+check ".claude-plugin/plugin.json (.version)"                  "$(git show :.claude-plugin/plugin.json | jq -r '.version')"
+check ".github/plugin/marketplace.json (.metadata.version)"    "$(git show :.github/plugin/marketplace.json | jq -r '.metadata.version')"
+check ".github/plugin/marketplace.json (.plugins[0].version)"  "$(git show :.github/plugin/marketplace.json | jq -r '.plugins[0].version')"
+check ".claude-plugin/marketplace.json (.metadata.version)"    "$(git show :.claude-plugin/marketplace.json | jq -r '.metadata.version')"
+check ".claude-plugin/marketplace.json (.plugins[0].version)"  "$(git show :.claude-plugin/marketplace.json | jq -r '.plugins[0].version')"
 
 if $mismatch; then
   echo ""

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-commit hook: validate that all plugin config file versions are aligned.
+# Only runs when at least one of the watched version-bearing config files is staged.
+#
+# Requires: jq (https://jqlang.org)
+
+set -euo pipefail
+
+WATCHED_FILES=(
+  "plugin.json"
+  ".claude-plugin/plugin.json"
+  ".github/plugin/marketplace.json"
+  ".claude-plugin/marketplace.json"
+)
+
+staged="$(git diff --cached --name-only)"
+any_staged=false
+
+for f in "${WATCHED_FILES[@]}"; do
+  if echo "$staged" | grep -qF "$f"; then
+    any_staged=true
+    break
+  fi
+done
+
+if ! $any_staged; then
+  exit 0
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "husky pre-commit: jq is required for version validation. See https://jqlang.org/download/"
+  exit 1
+fi
+
+plugin_version="$(jq -r '.version' plugin.json)"
+mismatch=false
+
+check() {
+  local label="$1"
+  local actual="$2"
+  if [[ "$actual" != "$plugin_version" ]]; then
+    echo "  Version mismatch — $label: expected $plugin_version, got $actual"
+    mismatch=true
+  fi
+}
+
+check ".claude-plugin/plugin.json (.version)"                  "$(jq -r '.version'            .claude-plugin/plugin.json)"
+check ".github/plugin/marketplace.json (.metadata.version)"    "$(jq -r '.metadata.version'   .github/plugin/marketplace.json)"
+check ".github/plugin/marketplace.json (.plugins[0].version)"  "$(jq -r '.plugins[0].version' .github/plugin/marketplace.json)"
+check ".claude-plugin/marketplace.json (.metadata.version)"    "$(jq -r '.metadata.version'   .claude-plugin/marketplace.json)"
+check ".claude-plugin/marketplace.json (.plugins[0].version)"  "$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
+
+if $mismatch; then
+  echo ""
+  echo "Fix with: npm run set-version -- <new-version>"
+  exit 1
+fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     "[markdown]": {
         "editor.formatOnSave": true,
         "editor.formatOnPaste": true
+    },
+    "chat.tools.terminal.autoApprove": {
+        "npm install": true
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Agent Kit is now a shared GitHub Copilot plugin repository. It packages custom a
 └── instructions/                       # Kept in repo, outside the plugin MVP
 ```
 
-The current plugin MVP covers `agents/`, `commands/`, `skills/`, `copilot-instructions.md`, and supporting docs they reference. The `instructions/` folder remains in the repo, but it is not yet packaged as a plugin-specific feature.
+The current plugin MVP covers `agents/`, `commands/`, `skills/`, and supporting docs they reference. The `instructions/` folder remains in the repo, but it is not yet packaged as a plugin-specific feature.
 
 `plugin.json` at the repository root is the canonical Copilot CLI manifest. `.github/plugin/marketplace.json` enables VS Code's "Chat: Install Plugin From Source" and the Copilot CLI marketplace command (`copilot plugin marketplace add`). The `.claude-plugin/` directory mirrors both files for Claude Code and other compatible scanners.
 
@@ -99,12 +99,8 @@ Browse the ecosystem at `https://skills.sh`.
 | Skills | GitHub repository source |
 | --- | --- |
 | `agent-device` | [`callstackincubator/agent-device`](https://github.com/callstackincubator/agent-device) |
-| `art-of-comment` | [`rakaadi/agent-kit`](https://github.com/rakaadi/agent-kit) |
 | `building-native-ui` | [`expo/skills`](https://github.com/expo/skills) |
-| `code-debugging` | [`rakaadi/agent-kit`](https://github.com/rakaadi/agent-kit) |
-| `code-refactoring` | [`rakaadi/agent-kit`](https://github.com/rakaadi/agent-kit) |
 | `expo-deployment` | [`expo/skills`](https://github.com/expo/skills) |
-| `find-skills` | [`vercel-labs/skills`](https://github.com/vercel-labs/skills) |
 | `git-commit` | [`github/awesome-copilot`](https://github.com/github/awesome-copilot) |
 | `javascript-testing-patterns` | [`wshobson/agents`](https://github.com/wshobson/agents) |
 | `mcp-builder` | [`anthropics/skills`](https://github.com/anthropics/skills) |

--- a/agents/codebase-analyzer.agent.md
+++ b/agents/codebase-analyzer.agent.md
@@ -1,8 +1,9 @@
 ---
-name: codebase-analyzer
+name: Codebase Analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
-tools: Read, Grep, Glob, LS
-model: sonnet
+tools: [read, search, agent, web, execute/runInTerminal, execute/getTerminalOutput, execute/sendToTerminal, execute/createAndRunTask]
+user-invocable: false
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.

--- a/commands/phase-plan-from-spec.prompt.md
+++ b/commands/phase-plan-from-spec.prompt.md
@@ -2,7 +2,7 @@
 name: phase-plan-from-spec
 description: Draft a plan for one implementation phase from a spec section.
 argument-hint: "phase=<phase> spec=<relative spec path> section=<spec section>"
-agent: plan
+agent: Plan
 ---
 
 Draft a plan for exactly one implementation phase. Do not implement.
@@ -42,7 +42,7 @@ Out of Scope when relevant.
 
 ### Template
 
-````markdown
+```markdown
 # Phase N — [Phase Name] Implementation Plan
 
 > **For agentic workers:** Prefer retrieval-led reasoning over pre-training-led

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "agent-kit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-kit",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-kit",
-  "version": "2026.3.1",
+  "version": "1.0.0",
   "description": "Shared GitHub Copilot plugin with custom agents, skills, prompts, hooks, and reference docs",
   "type": "module",
   "files": [
@@ -39,5 +39,12 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rakaadi/agent-kit.git"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
+  },
+  "scripts": {
+    "prepare": "husky",
+    "set-version": "bash scripts/update-version.sh"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,17 +1,36 @@
 # Hook Scripts
 
-This folder contains the command scripts referenced by [`hooks.json`](../hooks.json).
+This folder contains the command scripts referenced by [`hooks.json`](../hooks.json) and release utility scripts.
 
-## Included hooks
+## Agent hook scripts
 
 | Hook event | Script | Purpose |
 | --- | --- | --- |
 | `PreToolUse` | [`pre-tool-use-python.mjs`](./pre-tool-use-python.mjs) | Warns when a shell command uses bare `python` and recommends `python3` instead. |
 | `PostToolUse` | [`post-tool-use-eslint.mjs`](./post-tool-use-eslint.mjs) | Runs touched-file ESLint after successful file edits so agents avoid unnecessary repo-wide lint runs. |
 
-## Notes
+## Release utilities
 
-- The hook wiring lives in [`hooks.json`](../hooks.json).
-- The ESLint hook only reacts to successful file-modifying tool calls.
-- The ESLint hook caches successful results for the current touched-file set.
-- If repo-local ESLint is unavailable, the ESLint hook skips cleanly.
+| Script | Purpose |
+| --- | --- |
+| [`update-version.sh`](./update-version.sh) | Updates the version field in all plugin config files at once. |
+
+### `update-version.sh`
+
+Keeps `plugin.json`, `.claude-plugin/plugin.json`, and both `marketplace.json` files in sync by updating them all to the supplied version in one step.
+
+```sh
+npm run set-version -- 2026.4.3
+# or directly:
+bash scripts/update-version.sh 2026.4.3
+```
+
+**Requires [`jq`](https://jqlang.org/download/)** — the script exits with an error if jq is not found.
+
+---
+
+## Pre-commit hook
+
+A Husky pre-commit hook lives at [`.husky/pre-commit`](../.husky/pre-commit). It checks version alignment across all plugin config files **only when one of those files is staged**, blocking the commit if any version mismatches are found.
+
+Run `npm install` once to activate the hook via the `prepare` lifecycle script.

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Usage: bash scripts/update-version.sh <new-version>
+#         npm run set-version -- <new-version>
+#
+# Updates the version field in all plugin config files at once:
+#   plugin.json
+#   .claude-plugin/plugin.json  (copy of plugin.json — must stay byte-for-byte identical)
+#   .github/plugin/marketplace.json  (metadata.version + plugins[0].version)
+#   .claude-plugin/marketplace.json  (copy of .github/plugin/marketplace.json)
+#
+# Requires: jq (https://jqlang.org)
+
+set -euo pipefail
+
+NEW_VERSION="${1:-}"
+
+if [[ -z "$NEW_VERSION" ]]; then
+  echo "Error: version argument is required."
+  echo "Usage: $0 <new-version>  (e.g. $0 2026.4.3)"
+  exit 1
+fi
+
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]{4}\.[0-9]+\.[0-9]+$'; then
+  echo "Error: version must be in YYYY.M.D format (e.g. 2026.4.3), got: $NEW_VERSION"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not installed. See https://jqlang.org/download/"
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+update_json_field() {
+  local file="$REPO_ROOT/$1"
+  local filter="$2"
+  local tmp
+  tmp="$(mktemp)"
+  jq "$filter" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+echo "Updating plugin version to $NEW_VERSION..."
+
+# 1. plugin.json (root)
+update_json_field "plugin.json" ".version = \"$NEW_VERSION\""
+
+# 2. .claude-plugin/plugin.json — must be byte-for-byte identical to plugin.json
+cp "$REPO_ROOT/plugin.json" "$REPO_ROOT/.claude-plugin/plugin.json"
+
+# 3. .github/plugin/marketplace.json — two version fields
+update_json_field ".github/plugin/marketplace.json" \
+  ".metadata.version = \"$NEW_VERSION\" | .plugins[0].version = \"$NEW_VERSION\""
+
+# 4. .claude-plugin/marketplace.json — must be byte-for-byte identical
+cp "$REPO_ROOT/.github/plugin/marketplace.json" "$REPO_ROOT/.claude-plugin/marketplace.json"
+
+echo "Done. All plugin config files are now at version $NEW_VERSION."

--- a/skills/subagent-dispatch/SKILL.md
+++ b/skills/subagent-dispatch/SKILL.md
@@ -41,6 +41,7 @@ Custom agents live at `agents/<agent-name>.agent.md`.
 | **Bash Search Worker** | Shell-based repository search and filtering | Context isolation; read-only `execute` only | Subagent only |
 | **Code Simplifier** | Simplify and refine code for clarity | Preserves functionality; applies project standards | User + subagent |
 | **Compliance Reviewer** | Compare implementation against plan/spec | Deviation analysis; requirement verification | Subagent only |
+| **Codebase Analyzer** | Analyze implementation details of existing code | Precise file:line references; no speculation | Subagent only |
 | **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | Subagent only |
 | **Green** (TDD) | Write minimal code to pass a failing test | Never modifies tests; minimal production code | Subagent only |
 | **Orchestrator** | Delegate and coordinate multi-agent workflows | Never implements; dispatches and consolidates | User only |


### PR DESCRIPTION
Add a Husky pre-commit hook that checks staged plugin manifests for
version mismatches before commit.

Add scripts/update-version.sh to update plugin.json and both marketplace
manifest copies in one step while preserving the byte-for-byte equality
required by the release workflow.

Also wire the workflow into package.json and document the new release
steps in scripts/README.md.

Fixes #6