### PR TITLE
Fix reviewer group agent file reference issue

### DIFF
--- a/agents/codebase-analyzer.agent.md
+++ b/agents/codebase-analyzer.agent.md
@@ -1,7 +1,6 @@
 ---
 name: Codebase Analyzer
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better.
-tools: [read, search, agent, web, execute/runInTerminal, execute/getTerminalOutput, execute/sendToTerminal, execute/createAndRunTask]
 user-invocable: true
 model: Claude Sonnet 4.6 (copilot)
 ---

--- a/agents/codebase-analyzer.agent.md
+++ b/agents/codebase-analyzer.agent.md
@@ -1,8 +1,8 @@
 ---
 name: Codebase Analyzer
-description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
+description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better.
 tools: [read, search, agent, web, execute/runInTerminal, execute/getTerminalOutput, execute/sendToTerminal, execute/createAndRunTask]
-user-invocable: false
+user-invocable: true
 model: Claude Sonnet 4.6 (copilot)
 ---
 

--- a/agents/orchestrator.agent.md
+++ b/agents/orchestrator.agent.md
@@ -19,3 +19,66 @@ You are an **expert senior software engineer**, your role is the **orchestrator*
 - **Model Fallback Reference** — what to use when a preferred model is unavailable.
 
 Always write self-contained prompts. Subagents are stateless and have zero memory of this conversation.
+
+## Parallelization Rules
+
+**RUN IN PARALLEL when:**
+- Tasks touch different files
+- Tasks are in different domains (e.g., styling vs. logic)
+- Tasks have no data dependencies
+
+**RUN SEQUENTIALLY when:**
+- Task B needs output from Task A
+- Tasks might modify the same file
+- Design must be approved before implementation
+
+## File Conflict Prevention
+
+When delegating parallel tasks, you MUST explicitly scope each agent to specific files to prevent conflicts.
+
+### Strategy 1: Explicit File Assignment
+In your delegation prompt, tell each agent exactly which files to create or modify:
+
+```
+Task 2.1 → Generalist: "Implement the theme context. Create src/contexts/ThemeContext.tsx and src/hooks/useTheme.ts"
+
+Task 2.2 → Generalist: "Create the toggle component in src/components/ThemeToggle.tsx"
+```
+
+### Strategy 2: When Files Must Overlap
+If multiple tasks legitimately need to touch the same file (rare), run them **sequentially**:
+
+```
+Phase 2a: Add theme context (modifies App.tsx to add provider)
+Phase 2b: Add error boundary (modifies App.tsx to add wrapper)
+```
+
+### Strategy 3: Component Boundaries
+For UI work, assign agents to distinct component subtrees:
+
+```
+UI Composer A: "Design the header section" → Header.tsx, NavMenu.tsx
+UI Composer B: "Design the sidebar" → Sidebar.tsx, SidebarItem.tsx
+```
+
+### Red Flags (Split Into Phases Instead)
+If you find yourself assigning overlapping scope, that's a signal to make it sequential:
+- ❌ "Update the main layout" + "Add the navigation" (both might touch Layout.tsx)
+- ✅ Phase 1: "Update the main layout" → Phase 2: "Add navigation to the updated layout"
+
+## CRITICAL: Never tell agents HOW to do their work
+
+When delegating, describe WHAT needs to be done (the outcome), not HOW to do it.
+
+### ✅ CORRECT delegation
+- "Fix the infinite loop error in SideMenu"
+- "Add a settings panel for the chat interface"
+- "Create the color scheme and toggle UI for dark mode"
+
+### ❌ WRONG delegation
+- "Fix the bug by wrapping the selector with useShallow"
+- "Add a button that calls handleClick and updates state"
+
+## Consolidation and Feedback
+
+After receiving outputs from subagents, your job is to consolidate their work and provide feedback. This includes:

--- a/agents/reviewer-group.agent.md
+++ b/agents/reviewer-group.agent.md
@@ -14,7 +14,7 @@ Your role is the review **orchestrator**. This is how you should conduct the rev
 1. **Initial Analysis**: Start by analyzing the code provided for review and the user's specific concerns or focus areas.
 2. **Peer-review Coordination**: Collaborate with other reviewer agents to gather diverse perspectives and insights. Use subagent-dispatch skill and call two Quality Reviewer agents (with Claude Opus 4.6 and Gemini 3.1 Pro), send them your initial analysis result, and let them review the code independently and provide their feedback.
 3. **Consolidation of Feedback**: Once you receive feedback from the peer reviewers, consolidate their findings, identify common issues, and prioritize them based on severity and impact. Refined and verify their feedback against your initial analysis and your own findings to ensure accuracy and relevance. If necessary, send follow-up questions to the peer reviewers for clarification or additional insights.
-4. **Reporting**: After all feedback is consolidated and verified, produce the final deliverable using the [Reviewer Group Report Contract](../docs/agent-references/code-review-output.md#reviewer-group-file-output).
+4. **Reporting**: After all feedback is consolidated and verified, produce the final deliverable using the [Reviewer Group Report Contract](https://raw.githubusercontent.com/rakaadi/agent-kit/refs/heads/main/docs/agent-references/code-review-output.md).
 
 ## What To Look For When Reviewing Code
 

--- a/commands/execute-phase-from-plan.prompt.md
+++ b/commands/execute-phase-from-plan.prompt.md
@@ -33,7 +33,8 @@ Before writing any code, complete these steps in order:
 
 4. **Determine starting point.** If tasks are already marked ✅ in
    the plan (from a prior invocation), skip them. Begin at the first
-   incomplete task.
+   incomplete task whose `Depends on` requirements are already satisfied.
+   If multiple tasks are ready, take the first ready task in the plan.
 
 5. **Ask only if blocked.** If a blocking ambiguity remains after
    reading the plan, the spec, and the code, ask one focused clarifying
@@ -42,16 +43,20 @@ Before writing any code, complete these steps in order:
 
 ## Phase 1 — Execute
 
-Work through tasks in their numbered order. For each task:
+Work through tasks in dependency order. Prefer the written order when
+multiple tasks are ready, but do not start a task until everything in
+`Depends on` is complete. For each task:
 
 ### Per-task protocol
 
 1. **Read the spec references.** Before starting the task, read the spec
-   sections cited in its title (e.g., "Spec §12 Step 3.2, §9"). These
-   contain the implementation detail the plan intentionally omits.
+   sections cited in its title or Description (e.g., "Spec §12 Step 3.2,
+   §9"). These contain the implementation detail the plan intentionally
+   omits.
 
 2. **Implement.** Write the code. Follow project conventions, the spec's
-   guidance, and any constraints noted in the task summary.
+   guidance, and any constraints noted in the task Description,
+   `Depends on`, and `Acceptance` fields.
 
 3. **Delegate when appropriate.** If a task aligns with a specialist
    subagent's domain (e.g., `ui-composer` for component layout,
@@ -67,15 +72,16 @@ Work through tasks in their numbered order. For each task:
    completion note.
 
 5. **Mark the task done.** After completing a task, update `plan.md`:
-   change `### Task N:` to `### Task N: ✅` so progress is visible
-   in the file. If running in `scope=task` mode, stop here.
+   change `#### Task \`task-id\`` to `#### Task \`task-id\` ✅` so
+   progress is visible in the file. If running in `scope=task` mode,
+   stop here.
 
 ### Error handling during execution
 
 - **Build or lint failure:** Attempt to fix. If the fix is outside this
-  phase's scope, revert your change, mark the task with ⚠️ instead of
-  ✅, and note the issue. Do not let a broken build propagate to the
-  next task.
+   phase's scope, revert your change, mark the task heading with ⚠️
+   instead of ✅, and note the issue. Do not let a broken build
+   propagate to the next task.
 - **Ambiguity in spec:** Re-read the referenced spec sections. If still
   unclear, make the most conservative choice, implement it, and flag the
   assumption in the completion report.
@@ -103,7 +109,7 @@ After all tasks are complete (or the single task in `scope=task` mode):
 Produce a completion summary with three sections:
 
 ### Completed tasks
-List each task by number and title. Note any deviations from the plan
+List each task by ID and title. Note any deviations from the plan
 (files touched that weren't in File Structure, out-of-scope fixes
 applied, subagents dispatched).
 

--- a/commands/phase-plan-from-spec.prompt.md
+++ b/commands/phase-plan-from-spec.prompt.md
@@ -38,6 +38,9 @@ Every section marked **[required]** must appear with that exact heading.
 Sections marked **[optional]** may be added between Verification and
 Out of Scope when relevant.
 
+Use stable task IDs plus explicit `**Depends on**` metadata so agents can
+see what may run in parallel and humans can see what must wait.
+
 ---
 
 ### Template
@@ -50,6 +53,10 @@ Out of Scope when relevant.
 > incomplete. Always consult the skills before writing code.
 
 **Goal:** [One sentence — what this phase achieves when done.]
+
+**Architecture:** [2-3 sentences about the approach for this phase.]
+
+**Tech Stack:** [Key technologies, libraries, or tools used in this phase.]
 
 **Spec source:** `[spec file path]` — [section heading(s) referenced]
 
@@ -76,23 +83,36 @@ All files this phase will create or modify, listed once before the tasks.
 
 ## Tasks [required]
 
-Numbered sequence. Each task includes:
-- A title anchored to a spec step reference.
-- The files it touches (subset of the File Structure table).
-- A file-anchored summary: what to do and where, with spec section
-  references for detail. No pseudo-code or implementation blueprints.
+Dependency-aware task list. Each task includes:
+- A stable task ID.
+- An action-oriented title.
+- A short `Description` opener followed by actionable bullet points.
+- Explicit `Depends on`, `Produces`, and `Acceptance` fields.
+- File-anchored instructions and spec references inside the Description.
+- Enough separation that independent tasks can run in parallel when
+  dependencies allow.
 
-### Task 1: [Action verb] + [subject] (Spec §[X] Step [Y.Z])
+#### Task `task-id`
 
-**Files:**
-- Create: `path/to/new-file.ts`
-- Modify: `path/to/existing-file.ts`
+**Title**: [Action verb] + [subject].
 
-[Summary paragraph: what this task accomplishes, which spec sections
-contain the relevant detail, and any constraints the execution agent
-should respect.]
+**Description**: [One short sentence that explains what this task
+accomplishes and why it exists.]
 
-### Task 2: ...
+- Create or modify `path/to/file.ts` for [specific responsibility].
+- Reuse `path/to/reference.ts` as the reference surface for existing
+  patterns or types.
+- Preserve [named constraint, public API, or runtime behavior] while
+  making the change.
+- Use Spec §[X] and Spec §[Y.Z] as the detail sources for this task.
+
+**Depends on**: `upstream-task-id` or Nothing.
+
+**Produces**: `path/to/file.ts`; updated `path/to/other-file.ts`
+
+**Acceptance**: [Observable outcome that proves the task is done.]
+
+#### Task `next-task-id`
 
 [Continue for every task in the phase.]
 
@@ -119,3 +139,30 @@ Explicit list of work that belongs to later phases or is excluded.
 Reference the phase number or spec section where it belongs.
 
 - [item] → Phase [N] / Spec §[X]
+```
+
+## Structural rules
+
+1. **One phase per plan.** Never combine phases.
+2. **Spec traceability is required.** Every task must reference at least
+  one spec step or section in its Description.
+3. **Tasks must stay file-anchored.** Anchor each task to specific files
+  in its Description or Produces field.
+4. **`Depends on` is required.** Use `Nothing` only when the task can
+  start immediately.
+5. **Use concise descriptions.** Prefer a short opener plus actionable
+  bullets. If the task truly has one thing to do, one short paragraph is
+  acceptable.
+6. **Do not put implementation detail in the plan.** No code snippets,
+  pseudo-code, or step-by-step implementation sequences.
+7. **Expose safe parallel work.** Do not invent dependencies when two
+  tasks can proceed independently.
+
+## After writing the plan
+
+Summarize:
+- Whether all prerequisites are satisfied and any blocker that remains.
+- The task count and high-level task IDs.
+- Which tasks can start immediately and which wait on dependencies.
+
+Do not start implementation.

--- a/skills/subagent-dispatch/SKILL.md
+++ b/skills/subagent-dispatch/SKILL.md
@@ -41,8 +41,8 @@ Custom agents live at `agents/<agent-name>.agent.md`.
 | **Bash Search Worker** | Shell-based repository search and filtering | Context isolation; read-only `execute` only | Subagent only |
 | **Code Simplifier** | Simplify and refine code for clarity | Preserves functionality; applies project standards | User + subagent |
 | **Compliance Reviewer** | Compare implementation against plan/spec | Deviation analysis; requirement verification | Subagent only |
-| **Codebase Analyzer** | Analyze implementation details of existing code | Precise file:line references; no speculation | Subagent only |
-| **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | User + subagent |
+| **Codebase Analyzer** | Analyze implementation details of existing code | Precise file:line references; no speculation | User + subagent |
+| **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | Subagent only |
 | **Green** (TDD) | Write minimal code to pass a failing test | Never modifies tests; minimal production code | Subagent only |
 | **Orchestrator** | Delegate and coordinate multi-agent workflows | Never implements; dispatches and consolidates | User only |
 | **Quality Reviewer** | In-depth code review and analysis | Security, patterns, maintainability | Subagent only |

--- a/skills/subagent-dispatch/SKILL.md
+++ b/skills/subagent-dispatch/SKILL.md
@@ -42,7 +42,7 @@ Custom agents live at `agents/<agent-name>.agent.md`.
 | **Code Simplifier** | Simplify and refine code for clarity | Preserves functionality; applies project standards | User + subagent |
 | **Compliance Reviewer** | Compare implementation against plan/spec | Deviation analysis; requirement verification | Subagent only |
 | **Codebase Analyzer** | Analyze implementation details of existing code | Precise file:line references; no speculation | Subagent only |
-| **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | Subagent only |
+| **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | User + subagent |
 | **Green** (TDD) | Write minimal code to pass a failing test | Never modifies tests; minimal production code | Subagent only |
 | **Orchestrator** | Delegate and coordinate multi-agent workflows | Never implements; dispatches and consolidates | User only |
 | **Quality Reviewer** | In-depth code review and analysis | Security, patterns, maintainability | Subagent only |
@@ -57,7 +57,7 @@ Custom agents live at `agents/<agent-name>.agent.md`.
 
 ## Model Fallback Reference
 
-The platform now resolves model display names automatically. Use this table **only**
+**Always** use the model specified in the frontmatter. Use this table **only**
 when the agent's preferred model is temporarily unavailable:
 
 | Preferred model | Fallback |

--- a/skills/writing-plan/SKILL.md
+++ b/skills/writing-plan/SKILL.md
@@ -28,12 +28,12 @@ This structure informs the task decomposition. Each task should produce self-con
 
 ## Bite-Sized Task Granularity
 
-**Each step is one action (2-5 minutes):**
-- "Write the failing test" - step
-- "Run it to make sure it fails" - step
-- "Implement the minimal code to make the test pass" - step
-- "Run the tests and make sure they pass" - step
-- "Commit" - step
+**Each task should be one coherent, reviewable slice:**
+- Small enough that an execution agent can complete it without broad repo-wide reasoning.
+- Large enough to produce a meaningful artifact, boundary, or verification point.
+- Prefer tasks that touch different files or domains so independent work can run in parallel.
+- Make dependencies explicit with stable task IDs and `**Depends on**`.
+- If a task is truly one action, say that plainly instead of padding the description.
 
 ## Plan Document Header
 
@@ -55,50 +55,51 @@ This structure informs the task decomposition. Each task should produce self-con
 
 ## Task Structure
 
+Use a stable task ID plus explicit dependency metadata so agents can see what may run in parallel and humans can see what must wait. Write `Description` as a short opening sentence followed by actionable bullet points. If the task only has one thing to do, a single short paragraph is fine.
+
 ````markdown
-### Task N: [Component Name]
+#### Task `task-id`
 
-**Files:**
-- Create: `exact/path/to/file.py`
-- Modify: `exact/path/to/existing.py:123-145`
-- Test: `tests/exact/path/to/test.py`
+**Title**: [Action-oriented task title].
 
-- [ ] **Step 1: Write the failing test**
+**Description**: [One short sentence that explains what this task accomplishes and why it exists.]
 
-```python
-def test_specific_behavior():
-    result = function(input)
-    assert result == expected
-```
+- Create or modify `exact/path/to/file.ts` for [specific responsibility].
+- Reuse `exact/path/to/reference.ts` as the reference surface for existing patterns or types.
+- Preserve [named constraint, public API, or runtime behavior] while making the change.
+- Run `exact verification or lint command` if the task needs a concrete tooling step.
 
-- [ ] **Step 2: Run test to verify it fails**
+**Depends on**: `upstream-task-id` or Nothing.
 
-Run: `pytest tests/path/test.py::test_name -v`
-Expected: FAIL with "function not defined"
+**Produces**: `exact/path/to/file.ts`; updated `exact/path/to/other-file.ts`
 
-- [ ] **Step 3: Write minimal implementation**
+**Acceptance**: [Observable outcome that proves the task is done.]
 
-```python
-def function(input):
-    return expected
-```
+---
 
-- [ ] **Step 4: Run test to verify it passes**
+#### Task `shared-api-factory`
 
-Run: `pytest tests/path/test.py::test_name -v`
-Expected: PASS
+**Title**: Build the shared authenticated API factory.
 
-- [ ] **Step 5: Commit**
+**Description**: Move the duplicated authenticated request lifecycle behind one shared factory so both API slices use the same boundary.
 
-```bash
-git add tests/path/test.py src/path/file.py
-git commit -m "feat: add specific feature"
-```
+- Create `src/redux/createAuthenticatedApi.ts`.
+- Define `AuthenticatedApiConfig` with only the configuration current callers need.
+- Centralize request normalization, URL resolution, auth header injection, 401 refresh and retry, and reset-on-refresh-failure.
+- Preserve existing concurrency and retry behavior instead of introducing a new refresh mechanism.
+- Run `bunx eslint src/redux/createAuthenticatedApi.ts src/redux/authSessionHelpers.ts --fix`.
+
+**Depends on**: `auth-session-helpers`
+
+**Produces**: `src/redux/createAuthenticatedApi.ts`
+
+**Acceptance**: `createAuthenticatedApi` is the only place that knows how authenticated requests are executed, retried, and reset after refresh failure.
 ````
 
 ## Remember
 - Exact file paths always
-- Complete code in plan (not "add validation")
+- Stable task IDs and explicit dependencies
+- Concrete, file-anchored instructions in plan (not "add validation")
 - Exact commands with expected output
 - Reference relevant skills with @ syntax
 - DRY, YAGNI, TDD, frequent commits


### PR DESCRIPTION
- updates the reviewer group agent to correctly reference the report contract file using a GitHub raw file link, Fixes #8.
- make the codebase analyzer to be user-invocable 
- update the example task format to enhance clarity for agents and human dev.