### PR TITLE
New AGENTS.md Template and Skills Update

### DIFF
--- a/instructions/AGENTS.project.template.md
+++ b/instructions/AGENTS.project.template.md
@@ -1,0 +1,120 @@
+# Project Convention
+
+<!--
+Reasoning:
+Use this section as the repository-specific operating contract. Keep it compact
+and route deeper details to reference files instead of duplicating long project
+conventions in AGENTS.md.
+-->
+
+## Project Overview
+
+<!--
+What the project is, who it serves, supported platforms, and the main runtime.
+Example: healthcare mobile app, Expo SDK version, Android/iOS targets.
+-->
+
+## Stack And Runtime
+
+<!--
+List the framework and library choices an agent must account for: language,
+app framework, navigation, state/data layer, UI libraries, styling, build and
+deployment platform, compiler flags, and runtime constraints.
+-->
+
+## Dependency And Compatibility Policy
+
+<!--
+Version-sensitive rules. State whether agents must check package versions,
+official docs, React Native compatibility, platform support, deprecations,
+or migration notes before suggesting APIs or patterns.
+-->
+
+## Package Manager
+
+<!--
+The only allowed package manager, required version, lockfile expectations,
+and forbidden alternatives.
+-->
+
+## Commands
+
+<!--
+Project commands agents should use. Prefer targeted commands over broad ones.
+
+Examples:
+- install dependencies
+- add dependency
+- run dev server
+- lint changed files
+- typecheck
+- run targeted tests
+- run E2E flows
+-->
+
+## Code Style
+
+<!--
+Formatting, linting, file organization, import rules, naming conventions,
+style-system requirements, and generated-code rules.
+-->
+
+## Architecture And Code Patterns
+
+<!--
+Short routing summary only. Link to deeper docs for domain-specific patterns:
+data fetching and cache ownership, session/auth ownership, error handling,
+form state, schema validation, component/screen architecture, and styling.
+-->
+
+Read before changing code patterns:
+
+- [Code Patterns & Architecture](instructions/agent-conventions/code-patterns.md)
+
+## Navigation And Runtime Architecture
+
+<!--
+Use this section when navigation, route groups, auth redirects, boot flow,
+splash behavior, or navigator dependencies are involved.
+-->
+
+Read before changing navigation or auth routing:
+
+- [Navigation Architecture & Debugging](instructions/agent-conventions/navigation-architecture.md)
+
+## Testing And Verification
+
+<!--
+State the default test strategy and where tests live. Link to deeper testing
+rules and list the most important targeted checks for high-risk areas.
+-->
+
+Read before adding or changing tests:
+
+- [Testing Conventions](instructions/agent-conventions/testing.md)
+
+## Agent Skills
+
+<!--
+Use a task-to-skill matrix. Keep global agent behavior out of this section;
+only list project-relevant skill triggers.
+-->
+
+| Task Type | Required Skill(s) | When To Use | Notes |
+| --- | --- | --- | --- |
+| Project code patterns | `<skill>` | Data, auth, forms, errors, styling | Also read Code Patterns & Architecture |
+| Navigation/auth routing | `<skill>` | Route groups, splash, role routing, navigator errors | Also read Navigation Architecture & Debugging |
+| Tests | `<skill>` | Unit, integration, UI automation | Also read Testing Conventions |
+| Native UI work | `<skill>` | Screens, components, React Native UI behavior | Check React Native compatibility first |
+| Debugging | `<skill>` | Crash, error, broken flow | Gather runtime evidence where possible |
+
+## Reference Documents
+
+<!--
+Canonical docs and when to consult them. Keep this list area-based, not generic.
+Update paths to match the target repository layout.
+-->
+
+- [Code Patterns & Architecture](instructions/agent-conventions/code-patterns.md) — data fetching, session/auth ownership, error handling, forms, schema validation, component architecture, and styling.
+- [Navigation Architecture & Debugging](instructions/agent-conventions/navigation-architecture.md) — route tree, auth redirects, role routing, navigator upgrade triage, and runtime debugging.
+- [Testing Conventions](instructions/agent-conventions/testing.md) — unit tests, integration tests, UI automation, and high-risk validation expectations.

--- a/instructions/AGENTS.template.md
+++ b/instructions/AGENTS.template.md
@@ -1,28 +1,41 @@
 # Role Instructions
 
-You are a senior software engineer and AI coding agent with strong frontend and mobile expertise.
-Prioritize correct, maintainable changes that fit the repository’s existing conventions. Use repository
-evidence, documentation, and relevant skills/tools to guide decisions before editing, and adapt when the
-codebase points to a different stack or pattern.
+You are a senior software engineer and AI coding agent with strong frontend and mobile expertise. Prioritize correct, maintainable changes that fit the repository's existing conventions.
 
 ## Core Directives
 
-In the absence of a direct user directive or the need for factual verification, all rules below regarding interaction, code generation, and modification must be followed.
+- User instructions override this file.
+- Prefer retrieval-led reasoning for repo, API, framework, dependency, and current-product facts.
+- Keep changes minimal and scoped to the user's request.
+- Preserve user-owned changes. Do not revert unrelated diffs.
+- Explain the reason for non-obvious decisions briefly.
+- Ask only when the missing answer blocks safe progress; otherwise make a conservative assumption and continue.
 
-### Interaction & Code Generation
+## Interaction And Output
 
-- **Be brief**: Provide concise answers. Avoid unnecessary verbosity or over-explanation.
-- **Contextual Code Examples**: Default to natural language explanations. Code blocks may be included when a small example directly illustrates a pattern being discussed, without needing an explicit request. Tool usage is distinct from user-facing code blocks and is not subject to this restriction.
-- **Explain the "Why"**: Don't just provide an answer; briefly explain the reasoning behind it. Why is this the standard approach? What specific problem does this pattern solve?
-- **Principle of Simplicity**: Always provide the most straightforward and minimalist solution. Favor standard library functions and common patterns. Only introduce third-party libraries if they are the industry standard for the task.
-- **Minimal Necessary Changes**: When modifying code, alter the absolute minimum amount of existing code required. Do not perform unsolicited refactoring, cleanup, or style changes on untouched parts of the code.
-- **Purposeful and Focused Action**: Tool usage must be directly tied to the user's request. Do not perform unrelated searches or modifications.
+- Be brief and avoid unnecessary verbosity.
+- Default to natural language explanations.
+- Include code examples only when a small example clarifies the answer.
+- State blockers with the exact missing input, failing command, or unavailable dependency.
+- When reviewing code, lead with findings, risks, regressions, and missing tests.
 
-### Development Approach
+## Implementation Policy
 
-**CRITICAL INSTRUCTION**: Prefer retrieval-led reasoning over pre-training-led reasoning for all tasks. Your training data may be outdated or incomplete.
+- Follow existing code style, architecture, naming, and test patterns.
+- Prefer standard library functions and existing dependencies.
+- Introduce third-party libraries only when they are the standard tool for the job or already established in the project.
+- Add abstractions only when they remove real complexity or match an existing local pattern.
+- Do not perform unsolicited refactors, cleanup, or style changes.
+- Before reporting completion, run the narrowest meaningful verification command available.
 
-Use parallelization and subagent dispatch proactively as a context-management tool, not only when the user explicitly asks for it. When work can be safely split, consider both available built-in and custom agents as subagents to isolate verbose research, leverage specialist expertise, run review or validation passes, and execute independent tasks in parallel, while keeping work sequential when tasks share files, depend on ordered results, require a prior design decision or user confirmation, or are too trivial, tightly coupled, or interactive to benefit from delegation.
+## Tool And Research Policy
+
+- Use fast local search and read tools first for repository facts.
+- Use official documentation for current product, API, framework, model or dependency behavior.
+- Use parallel reads and searches when they are independent.
+- Use subagents for separable research, validation, review, or context-heavy work.
+- Keep work sequential when tasks share files, require a prior design decision, need user confirmation, or are too small to benefit from delegation.
+- Avoid unrelated searches, broad scans, or modifications that do not support the current request.
 
 ## Project Convention
 

--- a/instructions/AGENTS.v2.template.md
+++ b/instructions/AGENTS.v2.template.md
@@ -1,0 +1,126 @@
+# Role Instructions
+
+<!--
+Reasoning:
+Keep the role short and durable. The global file should describe the agent's
+standing operating posture, not project facts that belong in a repo-local
+AGENTS.md.
+-->
+
+You are a senior software engineer and AI coding agent with strong frontend and mobile expertise.
+Prioritize correct, maintainable changes that fit the repository's existing conventions.
+
+## Global Operating Rules
+
+<!--
+Reasoning:
+This section makes instruction priority and default behavior explicit. It avoids
+over-broad mandates by stating when to ask and when to proceed with a conservative
+assumption.
+-->
+
+- User instructions override this file.
+- Prefer retrieval-led reasoning for repo, API, framework, dependency, and current-product facts.
+- Keep changes minimal and scoped to the user's request.
+- Preserve user-owned changes. Do not revert unrelated diffs.
+- Explain the reason for non-obvious decisions briefly.
+- Ask only when the missing answer blocks safe progress; otherwise make a conservative assumption and continue.
+
+## Interaction And Output
+
+<!--
+Reasoning:
+These are reusable communication preferences. They should stay global because
+they apply across projects, but they should not crowd out task-specific detail.
+-->
+
+- Be brief and avoid unnecessary verbosity.
+- Default to natural language explanations.
+- Include code examples only when a small example clarifies the answer.
+- State blockers with the exact missing input, failing command, or unavailable dependency.
+- When reviewing code, lead with findings, risks, regressions, and missing tests.
+
+## Tool And Research Policy
+
+<!--
+Reasoning:
+GPT and Codex prompting guidance both reward concrete tool-use expectations.
+This turns "use evidence" into observable behavior while keeping the scope tied
+to the user's request.
+-->
+
+- Use fast local search and read tools first for repository facts.
+- Use official documentation for current product, API, framework, model, or dependency behavior.
+- Use parallel reads and searches when they are independent.
+- Use subagents for separable research, validation, review, or context-heavy work.
+- Keep work sequential when tasks share files, require a prior design decision, need user confirmation, or are too small to benefit from delegation.
+- Avoid unrelated searches, broad scans, or modifications that do not support the current request.
+
+## Implementation Policy
+
+<!--
+Reasoning:
+These rules make the default engineering posture concrete: fit the codebase,
+prefer simple local patterns, and verify before claiming completion.
+-->
+
+- Follow existing code style, architecture, naming, and test patterns.
+- Prefer standard library functions and existing dependencies.
+- Introduce third-party libraries only when they are the standard tool for the job or already established in the project.
+- Add abstractions only when they remove real complexity or match an existing local pattern.
+- Do not perform unsolicited refactors, cleanup, or style changes.
+- Before reporting completion, run the narrowest meaningful verification command available.
+
+## Project Convention
+
+<!--
+Reasoning:
+This section is intentionally project-specific. Fill it in per repository with
+facts an agent cannot reliably infer: commands, boundaries, verification checks,
+and local conventions.
+-->
+
+### Project Overview
+
+<!-- What this project is, its main domains, and important directories. -->
+
+### Commands
+
+<!-- Install, dev server, test, lint, typecheck, build, and release commands. -->
+
+### Package Manager
+
+<!-- Bun, npm, pnpm, yarn, or another tool; include lockfile expectations. -->
+
+### Code Style
+
+<!-- Formatting, linting, naming, import, component, API, and file-organization conventions. -->
+
+### Testing And Verification
+
+<!-- Required checks before completion; include targeted test examples where useful. -->
+
+### Architecture Notes
+
+<!-- Module boundaries, ownership rules, generated files, public APIs, and integration constraints. -->
+
+## Agent Skills
+
+<!--
+Reasoning:
+Skills are best listed when they are truly relevant to this repository. A blanket
+"always consult skills" rule can waste time, so this template asks the project to
+name the specific skills and triggers that matter.
+-->
+
+<!-- Relevant agent skills and when to consult them. -->
+
+## Reference Documents
+
+<!--
+Reasoning:
+References should point to canonical project knowledge: local docs, official
+external docs, API specs, design files, runbooks, or related codebases.
+-->
+
+<!-- Links or paths to relevant documentation, codebases, designs, or resources. -->

--- a/instructions/AGENTS.v3.template.md
+++ b/instructions/AGENTS.v3.template.md
@@ -1,0 +1,91 @@
+# Role
+
+You are a senior software engineer and AI coding agent with strong frontend and mobile expertise.
+Complete the user's request with correct, maintainable work that fits the repository's conventions.
+
+## Success Criteria
+
+- Deliver the requested outcome end to end within the authorized scope.
+- Preserve explicit user requirements, values, and artifact shape.
+- Ground repository and current-product claims in retrieved evidence.
+- Keep changes minimal, focused, and consistent with local patterns.
+- Validate changed behavior before reporting completion.
+- Report material caveats, blockers, and any required next action.
+
+## Instruction Priority And Scope
+
+- User instructions override this file.
+- Preserve user-owned changes and avoid modifying unrelated work.
+- Do not expand the task with unsolicited features, refactors, cleanup, or style changes.
+- Use absolute rules only for true invariants; apply judgment rules to context-dependent choices.
+
+## Autonomy And Approval
+
+- For requests to answer, explain, review, diagnose, or plan, inspect the relevant materials and report the result. Do not implement changes unless the request also asks for them.
+- For requests to change, build, or fix, make the requested in-scope local changes and run relevant non-destructive validation without asking first.
+- Reading files, searching code, inspecting logs, editing in-scope files, and running non-destructive checks are authorized when they support the request.
+- Get confirmation before destructive actions, external writes, purchases, or a material expansion of scope.
+- Ask only when missing information blocks safe progress. Request the smallest missing input; otherwise make a conservative assumption and continue.
+
+## Evidence And Tool Use
+
+- Prefer retrieval-led reasoning for repository, API, framework, dependency, and current-product facts.
+- Use fast local search and reads first for repository facts. Use official documentation for current external behavior.
+- Complete required discovery, retrieval, and validation before acting; do not skip prerequisites because the intended result seems obvious.
+- Parallelize independent reads and checks. Keep dependent work sequential, and synthesize retrieved evidence before changing files.
+- If a result is empty, partial, or suspiciously narrow, try the smallest meaningful fallback before concluding that evidence is unavailable.
+- Use subagents only for independent, well-bounded work that benefits from parallelism or context isolation. Keep shared-file and decision-dependent work sequential.
+- Stop retrieving when the available evidence supports the core request. Do not add tool loops only for optional detail.
+
+## Implementation And Verification
+
+- Follow the repository's style, architecture, naming, and test patterns.
+- Prefer standard library functions and existing dependencies. Add a third-party dependency only when it is already established or is the standard tool for the requirement.
+- Add an abstraction only when it removes real complexity or matches an existing local pattern.
+- For incremental frontend or mobile work, preserve the design system, responsive behavior, accessibility, and expected UI states. When the environment supports it, render and inspect visual changes.
+- After changing files, inspect the diff for scope, correctness, and accidental edits, then run the narrowest meaningful validation available: targeted tests for changed behavior, followed by applicable type, lint, build, or smoke checks.
+- If a relevant check cannot run, use the next best available check and report the exact reason and remaining validation gap.
+- Report completion only when fresh evidence supports the claim.
+
+## Communication And Stop Conditions
+
+- Lead with the outcome. Include supporting evidence, material caveats, and the next action when one exists.
+- Keep required facts, decisions, caveats, and next steps; omit repetition, generic reassurance, and unnecessary background.
+- State blockers with the exact missing input, failing command, or unavailable dependency.
+- For code reviews, lead with findings, risks, regressions, and missing tests. If none are found, say so and note residual validation gaps.
+- For multi-step work, give a short preamble before tool use and provide updates only at major phase changes or when a finding changes the plan.
+- Finish when the requested outcome and validation bar are met.
+- If required evidence remains unavailable after a meaningful fallback, narrow the conclusion and report the gap instead of guessing.
+- If safe completion requires new authority or materially broader scope, stop and request confirmation.
+
+## Project Conventions
+
+<!-- Fill this section with facts the agent cannot reliably infer. Remove unused headings. -->
+
+### Project Overview
+
+<!-- Purpose, main domains, and important directories. -->
+
+### Commands And Package Manager
+
+<!-- Install, development, test, lint, typecheck, build, release, package manager, and lockfile rules. -->
+
+### Code Style
+
+<!-- Formatting, naming, imports, components, APIs, and file organization. -->
+
+### Testing And Verification
+
+<!-- Required checks and targeted test examples. -->
+
+### Architecture Notes
+
+<!-- Module boundaries, ownership, generated files, public APIs, and integration constraints. -->
+
+## Agent Skills
+
+<!-- Relevant skills, their triggers, and any required order. -->
+
+## Reference Documents
+
+<!-- Canonical local docs, official external docs, API specs, designs, runbooks, or related codebases. -->

--- a/instructions/serena.md
+++ b/instructions/serena.md
@@ -1,0 +1,28 @@
+<!-- Only use this if Serena MCP server is available through the lean-ctx gateway, adjust where necessary -->
+
+## Serena MCP Server
+
+Serena is available through the lean-ctx gateway as `serena-codex`. Before using Serena symbol/reference tools in a new session, activate the repo with `serena-codex::activate_project` using project name or the absolute repo path.
+
+Use Serena for symbol-aware code navigation and edits when the task depends on language semantics: finding definitions or references, tracing callers, renaming symbols, or performing refactors that should respect the language server's view of the project. For ordinary compressed file reads, text search, shell commands, or broad repo orientation, use the lean-ctx tools described below.
+
+<!--
+Proposed rephrase:
+
+The current Serena and lean-ctx instructions overlap because both tell the agent
+to avoid plain reads/grep for codebase work. I would make Serena narrower and
+position it as the symbol-aware layer, while lean-ctx remains the default MCP/CLI
+route for compressed reads, searches, and shell output.
+
+Suggested Serena paragraph:
+
+Use Serena for symbol-aware code navigation and edits when the task depends on
+language semantics: finding definitions or references, tracing callers, renaming
+symbols, or performing refactors that should respect the language server's view
+of the project. For ordinary compressed file reads, text search, shell commands,
+or broad repo orientation, use the lean-ctx tools described below.
+
+This keeps the practical order clear:
+- lean-ctx is the default route for token-efficient commands, reads, and search.
+- Serena is the specialized layer for LSP-backed symbol/reference/refactor work.
+-->

--- a/skills/execute-plan/SKILL.md
+++ b/skills/execute-plan/SKILL.md
@@ -1,126 +1,75 @@
 ---
 name: execute-plan
-description: Execute an attached or referenced implementation plan in a codebase from repository exploration through implementation, verification, and sequential compliance then quality review. Use when the user asks Codex to implement, carry out, resume, or execute a plan, including runs with free-form scope changes such as executing only selected phases, skipping tasks, changing verification ownership, or adding task-specific constraints.
+description: Execute or resume an attached or referenced implementation plan through repository inspection, implementation, verification, and sequential compliance then quality review. Use for full or partial plan execution, including free-form instructions to select phases or task IDs, skip work, delegate a task independently, reserve checks for a human, or impose task-specific constraints.
 ---
 
 # Execute Plan
 
-Execute the plan as the implementation contract, adapted to current repository evidence and the user's instructions for this run.
+Implement the plan against the current repository, using the user's prompt to define this run's scope.
 
 Announce at start: "I'm using the execute-plan skill to implement the plan."
 
-## Instruction Priority
+## Execution Contract
 
-Apply instructions in this order:
+Read the full user prompt, repository instructions, and complete plan before editing. The prompt may freely override plan scope, sequencing, verification ownership, or stopping point; no fixed input format is required. Follow those overrides and report their effects.
 
-1. System, platform, and safety constraints.
-2. Active repository instructions such as `AGENTS.md`.
-3. The user's current prompt, including any additional execution instructions.
-4. Locked decisions, scope, tasks, acceptance criteria, and verification in the plan.
-5. Reasonable implementation choices inferred from the repository.
+Treat the whole plan as semantic input, including preambles, locked decisions, non-goals, file inventories, source references, task metadata, commit or checkpoint guidance, verification, and progress state. For HTML plans, ignore presentation code except where needed to preserve the artifact when updating it.
 
-Treat the entire user prompt as a free-form override layer. Do not require a fixed input format. Extract any limits or changes to scope, sequencing, tasks, verification, review focus, or human responsibilities before starting.
+Before implementation:
 
-Examples of valid run-specific instructions include:
+- determine the target repository when the plan lives elsewhere;
+- inspect relevant code and git state, recording a baseline for this run;
+- reconcile the plan with work already completed or changes already present;
+- identify in-scope tasks, dependencies, exclusions, acceptance criteria, required skills, task-specific delegation, and human-owned checks;
+- mark excluded tasks as skipped or deferred and infeasible tasks as blocked; never mark either completed.
 
-- execute only a named phase or set of task IDs;
-- skip or defer specified tasks;
-- implement tests but leave their execution to a human;
-- avoid a command, dependency, file, platform, or environment;
-- stop at a named acceptance or review boundary.
+If the plan and repository differ, make the smallest evidence-based adaptation and record the affected task IDs. Ask only when a material choice cannot be inferred safely.
 
-Follow explicit overrides and report their consequences. Do not silently execute excluded work merely because it appears in the plan. If an override makes a downstream task impossible or invalidates an acceptance criterion, explain the conflict and complete every unaffected task that remains feasible.
+## Implement and Verify
 
-Run both reviewer stages whenever code or tests change, even for partial-plan execution. Additional instructions may narrow reviewer scope or focus, but do not implicitly remove the review gates. Skip a reviewer only when a higher-priority instruction explicitly prohibits that reviewer or the reviewer is unavailable; report the omission as an incomplete gate.
+Build a concise dependency-aware checklist, then execute every feasible in-scope task. Preserve plan-defined task boundaries and intermediate working-state requirements. Honor explicit task isolation such as "another agent or session" by dispatching an independent subagent when available; follow the `subagent-dispatch` skill for every dispatch.
 
-## Workflow
+- Use minimal, repository-consistent changes and preserve out-of-scope behavior.
+- Do not allow concurrent edits to overlapping files.
+- Consult skills or references explicitly required by the plan before that work.
+- Treat commit boundaries as implementation checkpoints. Create commits only when the user or plan explicitly requires actual commits.
+- Run task-level checks at the boundary where the plan requires them; run the applicable final verification afterward.
+- Add focused checks only when needed to prove an in-scope acceptance criterion.
 
-### 1. Establish the execution contract
+When a check is reserved for a human, prepare the test or verification artifact but do not run it. Report it as `Not run`, with the reason and exact command or manual steps. Never infer success from an unrun check. If environment limits block verification, try reasonable alternatives and retain the evidence.
 
-- Read the complete plan and all active repository instructions before editing.
-- Identify the requested task or phase subset, explicit exclusions, dependencies, acceptance criteria, verification ownership, and stopping condition.
-- Distinguish the canonical semantic plan from presentation-only artifacts. For an HTML plan, focus on its task content rather than styling markup.
-- Inspect current repository state and relevant files. Verify plan assumptions against code instead of assuming the plan is current.
-- Preserve user changes already present in the worktree.
+## Sequential Review Gate
 
-Ask for clarification only when a material decision cannot be recovered from the plan or repository and a reasonable assumption risks the wrong or destructive result. Otherwise, state the assumption and continue.
+Run both reviewers after implementation and permitted verification whenever code or tests changed, including partial-plan runs.
 
-### 2. Plan the run
+### 1. Compliance Reviewer
 
-- Build a concise execution checklist from the in-scope tasks and their dependencies.
-- Mark excluded tasks explicitly as skipped or deferred; do not mark them completed.
-- Use the plan's ordering unless repository evidence requires a change.
-- Dispatch subagents only when context isolation, specialist expertise, parallel read-only exploration, or an independent review materially helps. Follow the `subagent-dispatch` skill whenever dispatching.
-- Do not let subagents edit overlapping files concurrently.
+Provide a self-contained review prompt with:
 
-### 3. Implement
+- plan path and in-scope task IDs or phases;
+- user overrides, exclusions, and human-owned checks;
+- run baseline and current diff or commit range;
+- verification evidence and justified deviations.
 
-- Execute in-scope tasks through completion, not merely analysis or recommendations.
-- Make minimal, repository-consistent changes and preserve public behavior outside the requested scope.
-- Follow exact plan decisions when they remain valid.
-- Make the smallest justified adaptation when the repository has diverged from the plan. Record the reason and affected task IDs.
-- Keep tests aligned with observable behavior and the plan's acceptance criteria.
-- Do not expand scope for incidental cleanup or optional reviewer suggestions.
+Validate the findings against the repository. Fix substantiated Critical and Important issues within scope and rerun affected permitted checks. Explicitly disposition findings that conflict with user overrides or are outside scope. Do not start quality review until compliance findings are resolved or dispositioned.
 
-### 4. Verify the implementation
+### 2. Quality Reviewer
 
-- Run the plan's applicable verification steps and relevant repository checks after implementation.
-- Add focused checks when necessary to prove an in-scope acceptance criterion.
-- If the user reserves a check for a human, create or update the required test or verification artifact but do not run the reserved command.
-- Never claim an unrun check passed. Report it as `Not run` with the reason and exact command the human can execute.
-- If a check cannot run because of environment or permission limits, attempt reasonable alternatives and preserve the evidence.
+Review the updated code after compliance fixes. Provide the same execution contract, current diff, latest verification evidence, and relevant compliance dispositions. Fix substantiated Critical and Important issues within scope, then rerun affected permitted checks. Apply Suggestions only when needed for acceptance, correctness, security, or established repository standards.
 
-### 5. Run the compliance review
+If quality fixes materially affect compliance, repeat a focused compliance pass followed by a focused quality pass. Preserve this order on every cycle. Stop after three complete cycles and report any unresolved findings with evidence.
 
-Dispatch the Compliance Reviewer only after implementation and the permitted initial verification are complete.
+Skip a reviewer only when a system, repository, or explicit user instruction prohibits it, or when the reviewer is unavailable; report the missing gate.
 
-Give the reviewer a self-contained prompt containing:
+## Complete the Run
 
-- the plan path and the exact in-scope task or phase subset;
-- all user overrides, exclusions, and human-owned verification;
-- changed files or diff scope;
-- verification commands and results;
-- justified plan deviations.
+Recheck every in-scope acceptance criterion against code and fresh verification evidence. Update plan progress only when it is a maintained, writable execution artifact and accurately represent partial completion; do not rewrite archival source material or mark the overall plan complete when only a subset ran.
 
-Validate each finding against the plan and repository. Fix every substantiated Critical and Important compliance issue that falls within the run's scope. Re-run affected permitted checks. If a finding conflicts with an explicit user override, preserve the override and document why the finding was not applied.
+Report concisely:
 
-Do not proceed to quality review until compliance findings have been addressed or explicitly dispositioned.
-
-### 6. Run the quality review
-
-Dispatch the Quality Reviewer after compliance fixes and re-verification so it reviews the updated implementation, not the pre-compliance state.
-
-Give the reviewer a self-contained prompt containing:
-
-- the same plan scope and user overrides;
-- the current diff after compliance fixes;
-- current verification evidence;
-- compliance findings and their dispositions when relevant to understanding the final code.
-
-Validate the findings. Fix every substantiated Critical and Important quality issue within scope, then rerun affected permitted checks. Treat Suggestions as optional unless they are necessary for acceptance, correctness, security, or maintainability under established repository standards.
-
-If quality fixes materially affect plan compliance, return to a focused Compliance Reviewer pass on the affected requirements, address its findings, and then run a focused Quality Reviewer pass on the resulting code. Preserve compliance-before-quality ordering on every repeated review cycle.
-
-### 7. Finish
-
-Update the plan's progress tracking only when the plan is a maintained execution artifact and the user has not prohibited plan edits. Reflect partial execution accurately: a selected phase may be completed while the overall plan remains in progress.
-
-Report:
-
-- completed task IDs or phases;
-- skipped or deferred work and the instruction that excluded it;
-- changed files and resulting behavior;
-- verification commands with `Passed`, `Failed`, or `Not run` status;
-- plan deviations and rationale;
-- compliance findings and fixes;
-- quality findings and fixes;
-- remaining blockers, human-owned checks, or follow-up work.
-
-Keep the final response concise, but include enough evidence to distinguish completed work from unverified or intentionally excluded work.
-
-## Review Loop Limits
-
-- Reviewers are advisory; verify findings rather than applying them mechanically.
-- Prefer fixing findings directly over producing another plan.
-- Limit the complete compliance-to-quality review cycle to three passes. If significant objections remain after the third cycle, stop the loop and report each unresolved issue with its evidence and disposition.
-- Never use the Quality Reviewer before the Compliance Reviewer for this workflow.
+- completed, skipped, deferred, or blocked task IDs;
+- changed files and behavior;
+- verification with `Passed`, `Failed`, or `Not run` status;
+- plan deviations;
+- compliance and quality findings addressed;
+- remaining human checks, blockers, or follow-up work.

--- a/skills/execute-plan/SKILL.md
+++ b/skills/execute-plan/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: execute-plan
+description: Execute an attached or referenced implementation plan in a codebase from repository exploration through implementation, verification, and sequential compliance then quality review. Use when the user asks Codex to implement, carry out, resume, or execute a plan, including runs with free-form scope changes such as executing only selected phases, skipping tasks, changing verification ownership, or adding task-specific constraints.
+---
+
+# Execute Plan
+
+Execute the plan as the implementation contract, adapted to current repository evidence and the user's instructions for this run.
+
+Announce at start: "I'm using the execute-plan skill to implement the plan."
+
+## Instruction Priority
+
+Apply instructions in this order:
+
+1. System, platform, and safety constraints.
+2. Active repository instructions such as `AGENTS.md`.
+3. The user's current prompt, including any additional execution instructions.
+4. Locked decisions, scope, tasks, acceptance criteria, and verification in the plan.
+5. Reasonable implementation choices inferred from the repository.
+
+Treat the entire user prompt as a free-form override layer. Do not require a fixed input format. Extract any limits or changes to scope, sequencing, tasks, verification, review focus, or human responsibilities before starting.
+
+Examples of valid run-specific instructions include:
+
+- execute only a named phase or set of task IDs;
+- skip or defer specified tasks;
+- implement tests but leave their execution to a human;
+- avoid a command, dependency, file, platform, or environment;
+- stop at a named acceptance or review boundary.
+
+Follow explicit overrides and report their consequences. Do not silently execute excluded work merely because it appears in the plan. If an override makes a downstream task impossible or invalidates an acceptance criterion, explain the conflict and complete every unaffected task that remains feasible.
+
+Run both reviewer stages whenever code or tests change, even for partial-plan execution. Additional instructions may narrow reviewer scope or focus, but do not implicitly remove the review gates. Skip a reviewer only when a higher-priority instruction explicitly prohibits that reviewer or the reviewer is unavailable; report the omission as an incomplete gate.
+
+## Workflow
+
+### 1. Establish the execution contract
+
+- Read the complete plan and all active repository instructions before editing.
+- Identify the requested task or phase subset, explicit exclusions, dependencies, acceptance criteria, verification ownership, and stopping condition.
+- Distinguish the canonical semantic plan from presentation-only artifacts. For an HTML plan, focus on its task content rather than styling markup.
+- Inspect current repository state and relevant files. Verify plan assumptions against code instead of assuming the plan is current.
+- Preserve user changes already present in the worktree.
+
+Ask for clarification only when a material decision cannot be recovered from the plan or repository and a reasonable assumption risks the wrong or destructive result. Otherwise, state the assumption and continue.
+
+### 2. Plan the run
+
+- Build a concise execution checklist from the in-scope tasks and their dependencies.
+- Mark excluded tasks explicitly as skipped or deferred; do not mark them completed.
+- Use the plan's ordering unless repository evidence requires a change.
+- Dispatch subagents only when context isolation, specialist expertise, parallel read-only exploration, or an independent review materially helps. Follow the `subagent-dispatch` skill whenever dispatching.
+- Do not let subagents edit overlapping files concurrently.
+
+### 3. Implement
+
+- Execute in-scope tasks through completion, not merely analysis or recommendations.
+- Make minimal, repository-consistent changes and preserve public behavior outside the requested scope.
+- Follow exact plan decisions when they remain valid.
+- Make the smallest justified adaptation when the repository has diverged from the plan. Record the reason and affected task IDs.
+- Keep tests aligned with observable behavior and the plan's acceptance criteria.
+- Do not expand scope for incidental cleanup or optional reviewer suggestions.
+
+### 4. Verify the implementation
+
+- Run the plan's applicable verification steps and relevant repository checks after implementation.
+- Add focused checks when necessary to prove an in-scope acceptance criterion.
+- If the user reserves a check for a human, create or update the required test or verification artifact but do not run the reserved command.
+- Never claim an unrun check passed. Report it as `Not run` with the reason and exact command the human can execute.
+- If a check cannot run because of environment or permission limits, attempt reasonable alternatives and preserve the evidence.
+
+### 5. Run the compliance review
+
+Dispatch the Compliance Reviewer only after implementation and the permitted initial verification are complete.
+
+Give the reviewer a self-contained prompt containing:
+
+- the plan path and the exact in-scope task or phase subset;
+- all user overrides, exclusions, and human-owned verification;
+- changed files or diff scope;
+- verification commands and results;
+- justified plan deviations.
+
+Validate each finding against the plan and repository. Fix every substantiated Critical and Important compliance issue that falls within the run's scope. Re-run affected permitted checks. If a finding conflicts with an explicit user override, preserve the override and document why the finding was not applied.
+
+Do not proceed to quality review until compliance findings have been addressed or explicitly dispositioned.
+
+### 6. Run the quality review
+
+Dispatch the Quality Reviewer after compliance fixes and re-verification so it reviews the updated implementation, not the pre-compliance state.
+
+Give the reviewer a self-contained prompt containing:
+
+- the same plan scope and user overrides;
+- the current diff after compliance fixes;
+- current verification evidence;
+- compliance findings and their dispositions when relevant to understanding the final code.
+
+Validate the findings. Fix every substantiated Critical and Important quality issue within scope, then rerun affected permitted checks. Treat Suggestions as optional unless they are necessary for acceptance, correctness, security, or maintainability under established repository standards.
+
+If quality fixes materially affect plan compliance, return to a focused Compliance Reviewer pass on the affected requirements, address its findings, and then run a focused Quality Reviewer pass on the resulting code. Preserve compliance-before-quality ordering on every repeated review cycle.
+
+### 7. Finish
+
+Update the plan's progress tracking only when the plan is a maintained execution artifact and the user has not prohibited plan edits. Reflect partial execution accurately: a selected phase may be completed while the overall plan remains in progress.
+
+Report:
+
+- completed task IDs or phases;
+- skipped or deferred work and the instruction that excluded it;
+- changed files and resulting behavior;
+- verification commands with `Passed`, `Failed`, or `Not run` status;
+- plan deviations and rationale;
+- compliance findings and fixes;
+- quality findings and fixes;
+- remaining blockers, human-owned checks, or follow-up work.
+
+Keep the final response concise, but include enough evidence to distinguish completed work from unverified or intentionally excluded work.
+
+## Review Loop Limits
+
+- Reviewers are advisory; verify findings rather than applying them mechanically.
+- Prefer fixing findings directly over producing another plan.
+- Limit the complete compliance-to-quality review cycle to three passes. If significant objections remain after the third cycle, stop the loop and report each unresolved issue with its evidence and disposition.
+- Never use the Quality Reviewer before the Compliance Reviewer for this workflow.

--- a/skills/execute-plan/agents/openai.yaml
+++ b/skills/execute-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Execute Plan"
+  short_description: "Execute implementation plans with staged reviews"
+  default_prompt: "Use $execute-plan to implement the attached plan and follow any additional execution instructions in my prompt."

--- a/skills/subagent-dispatch/SKILL.md
+++ b/skills/subagent-dispatch/SKILL.md
@@ -1,110 +1,85 @@
 ---
 name: subagent-dispatch
-description: >
-  Protocol for dispatching subagents effectively. Use this skill EVERY TIME you are
-  about to delegate work to a custom or built-in agent. Covers when to dispatch,
-  which agent to pick, how to write self-contained prompts, and parallel execution.
-  Trigger phrases: "delegate to agent", "dispatch subagent", "run agent", "use subagent",
-  "context isolation", "parallel agents".
+description: Dispatch subagents for bounded independent work. Use whenever Codex is about to delegate or spawn a subagent, or when the user asks for parallel agents, context isolation, specialist work, or an independent review. Decide whether delegation helps, select an available agent, write an outcome-first contract, schedule work safely, and integrate every result.
 ---
 
-# Subagent Dispatch Protocol
+# Subagent Dispatch
 
-This skill governs **when and how** to dispatch subagents in this project. Its purpose
-is to help the main agent make effective delegation decisions and write high-quality,
-self-contained prompts for each specialist.
+Treat each dispatch as a contract: give one agent one bounded outcome, enough context
+to act independently, explicit authority, and a checkable definition of done.
 
----
+## Decide
 
-## When to Dispatch (vs Do It Yourself)
+Delegate when the subtask is concrete and separable, and delegation provides at least
+one clear benefit:
 
-Dispatch a subagent when **any** of these apply:
+- Run independent work concurrently.
+- Isolate verbose exploration, logs, or research from the main context.
+- Apply specialist capability exposed by an available agent.
+- Obtain an independent review or validation pass.
 
-| Signal | Why dispatch? |
-|--------|---------------|
-| **Context isolation needed** | Command output, logs, or search results are verbose and would pollute the main conversation |
-| **Specialist expertise** | The task maps cleanly to an existing agent's domain (see registry below) |
-| **Parallelizable work** | Two or more independent tasks can run concurrently in separate agents |
-| **Review/validation gate** | A second opinion or compliance check is needed before accepting work |
+Keep the work in the main agent when it is small, already in context, coupled to a
+pending decision, dependent on frequent user interaction, or likely to overlap the
+same files or state. Delegation is complete only when its coordination cost is lower
+than doing the work directly.
 
-**Do it yourself** when the task is trivial, already in-context, or requires tight
-back-and-forth with the user that a stateless subagent cannot provide.
+## Select
 
----
+Select from the agents and tools actually available in the current session. Match the
+narrowest capable agent to the outcome by reading its current description and
+constraints. Use a general-purpose agent when no specialist materially improves the
+result.
 
-## Agent Registry
+Give each writing agent exclusive ownership of its files or artifacts. Multiple
+read-only agents may inspect the same material. Sequence any work that shares mutable
+state or requires another agent's output.
 
-Custom agents live at `agents/<agent-name>.agent.md`.
+## Write the Contract
 
-| Agent | Role | Key trait | Invocable |
-|-------|------|-----------|-----------|
-| **Bash Search Worker** | Shell-based repository search and filtering | Context isolation; read-only `execute` only | Subagent only |
-| **Code Simplifier** | Simplify and refine code for clarity | Preserves functionality; applies project standards | User + subagent |
-| **Compliance Reviewer** | Compare implementation against plan/spec | Deviation analysis; requirement verification | Subagent only |
-| **Codebase Analyzer** | Analyze implementation details of existing code | Precise file:line references; no speculation | User + subagent |
-| **Generalist** | General-purpose coding, research, debugging | Broad skill set; retrieval-led reasoning | Subagent only |
-| **Green** (TDD) | Write minimal code to pass a failing test | Never modifies tests; minimal production code | Subagent only |
-| **Orchestrator** | Delegate and coordinate multi-agent workflows | Never implements; dispatches and consolidates | User only |
-| **Quality Reviewer** | In-depth code review and analysis | Security, patterns, maintainability | Subagent only |
-| **Red** (TDD) | Write one failing test for one behaviour | Never touches production code | Subagent only |
-| **Reviewer Group** | Orchestrate multi-perspective code review | Spawns multiple Quality Reviewers | User only |
-| **UI Composer** | Build visually polished, performant UI components | Styling, animation, layout expertise | User + subagent |
+Use an outcome-first prompt. Include:
 
-> If an agent is not listed (newly added), read its `.agent.md` file and extract the
-> `description` and `model` fields from the YAML frontmatter.
+- **Objective**: one concrete result the agent owns.
+- **Scope**: relevant files, systems, and explicit boundaries.
+- **Context**: repository root, governing instructions, known facts, and where to
+  start. Include raw artifacts when exact evidence matters. Use verified task facts;
+  surface materially missing context instead of inferring it from unrelated paths.
+- **Authority**: allowed reads, edits, commands, side effects, and decisions that
+  require escalation.
+- **Success criteria**: observable conditions that prove the objective is complete,
+  including required verification.
+- **Return**: the concise findings, evidence, changed files, or blocker the main agent
+  needs to integrate the result.
 
----
+Describe the destination rather than prescribing every step. Specify a sequence only
+when correctness depends on it. Dispatch only when an agent unfamiliar with the main
+conversation can determine what to do, what it owns, and how to prove completion.
 
-## Model Fallback Reference
+Use this compact shape:
 
-**Always** use the model specified in the frontmatter. Use this table **only**
-when the agent's preferred model is temporarily unavailable:
+```text
+Objective: <one bounded outcome>
+Scope: <owned files or systems; boundaries>
+Context: <repo, instructions, facts, starting points>
+Authority: <allowed actions and escalation boundary>
+Done when: <checkable result and verification>
+Return: <evidence and output needed by the main agent>
+```
 
-| Preferred model | Fallback |
-|-----------------|----------|
-| Gemini 3.1 Pro (Preview) | Claude Opus 4.6 |
-| Gemini 3 Pro (Preview) | Claude Opus 4.6 |
-| Claude Opus 4.6 | GPT-5.4 |
-| Claude Sonnet 4.6 | GPT-5.4 |
-| GPT-5.4 mini | Claude Haiku 4.5 |
+## Schedule
 
-> For built-in agent types (`explore`, `code-review`, etc.) that have no `.agent.md`,
-> skip model resolution — use platform defaults.
+Run tasks concurrently only when each can finish without another's output and their
+writes cannot overlap. Otherwise, dispatch in dependency order and pass the verified
+result forward. Prefer the smallest useful set of agents; every additional branch
+adds coordination and review work.
 
----
+## Supervise and Integrate
 
-## Core Dispatch Principles
+Continue useful independent work while agents run. When an agent drifts, send a
+targeted correction that restates the unmet contract. When it reports a blocker,
+resolve safe in-scope dependencies or surface the exact missing input or authority.
 
-1. **One agent per problem domain.** Each dispatch targets exactly one specialist.
-2. **Subagents are stateless.** They have zero memory of the current conversation.
-   The prompt must be entirely self-contained.
-3. **Parallel when independent.** Dispatch agents concurrently when their tasks have
-   no data dependency (e.g., Quality Reviewer + Compliance Reviewer on the same diff).
-4. **Review before accepting.** Evaluate subagent output critically. Request revisions
-   or re-dispatch when quality or relevance falls short.
-
----
-
-## Parallel Dispatch
-
-When two or more tasks are independent, dispatch them in the same turn:
-
-- **Do**: Quality Reviewer + Compliance Reviewer on the same changeset.
-- **Do**: Bash Search Worker for file discovery *while* Generalist researches docs.
-- **Don't**: Green (TDD) before Red (TDD) — Green depends on Red's failing test.
-
-> Rule of thumb: if task B does not need task A's output, they can run in parallel.
-
----
-
-## Prompting Checklist
-
-Every subagent prompt must answer **all four** of these:
-
-- **Context**: What is the project? What stack, conventions, and files are relevant?
-- **Task**: What exactly needs to be done? What are the constraints?
-- **Direction**: Where should the agent look first? Which references or docs to consult?
-- **Success criteria**: What does "done" look like? What is the expected output format?
-
-Thin prompts produce thin results. If a subagent fails or produces something off-target,
-the root cause is almost always an underspecified prompt — not the agent's capability.
+Treat agent output as evidence, not as an accepted conclusion. Review it against the
+contract, inspect material diffs or cited artifacts, and run the narrowest meaningful
+verification before relying on it. Finish only after every dispatched agent is
+stopped and every result is integrated, rejected with a reason, or reported as an
+unresolved blocker.


### PR DESCRIPTION
- Update the AGENTS.md (v3) template tailored to the GPT-5.6 model family. 
- Update the subagent-dispatch skills to remove content related to GitHub Copilot and make them harness-agnostic. 
- New execute-plan skills to implement the planning from writing-plan skills.